### PR TITLE
New adapter version 2.1.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,20 @@
+# 2.1.4
+ 
+- Testing file:
+the test file has been added with 8 tests and 8 success (system-tester.html).
+npm run debug  and reach /system-tester.html
+result: 8 specs, 0 failures
+ 
+- ESLint:
+Adapter file has been cleaned and succesfuly pass:
+npm run lint
+
+- Adapter changes:
+Some edit to change the rubicon key (hb_pb_ixrubicon) for reporting only.
+The ad is still correctly displayed on both the safeFrame and no safeFrame slots
+2 sizes have been added to the sizeToSizeIdMapping
+ 
+# 2.1.3
+ 
+Previous version used.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       }
     },
     "adapter-development-suite": {
-      "version": "git+https://github.com/indexexchange/adapter-development-suite.git#d27a83ecf79e70b1a8baac49e0fee6fd99e463c0",
+      "version": "git+https://github.com/indexexchange/adapter-development-suite.git#172d0198aef05cd437d286e28bfd0bd35ed6a754",
       "from": "git+https://github.com/indexexchange/adapter-development-suite.git",
       "dev": true,
       "requires": {
@@ -124,8 +124,8 @@
       "integrity": "sha1-XmYjDlIZ/j6JUqTvtPIPrllqgTo=",
       "dev": true,
       "requires": {
-        "colour": "latest",
-        "optjs": "latest"
+        "colour": "^0.7.1",
+        "optjs": "^3.2.2"
       }
     },
     "babel-code-frame": {
@@ -170,21 +170,32 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
-        "iconv-lite": "0.4.19",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
         "on-finished": "~2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
       }
     },
     "brace-expansion": {
@@ -610,14 +621,14 @@
       "dev": true
     },
     "express": {
-      "version": "4.16.3",
-      "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
-      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
-        "body-parser": "1.18.2",
+        "body-parser": "1.18.3",
         "content-disposition": "0.5.2",
         "content-type": "~1.0.4",
         "cookie": "0.3.1",
@@ -634,10 +645,10 @@
         "on-finished": "~2.3.0",
         "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.3",
-        "qs": "6.5.1",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
         "range-parser": "~1.2.0",
-        "safe-buffer": "5.1.1",
+        "safe-buffer": "5.1.2",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
@@ -645,6 +656,14 @@
         "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "external-editor": {
@@ -1035,18 +1054,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-      "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-      "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+      "version": "2.1.21",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
       "dev": true,
       "requires": {
-        "mime-db": "~1.36.0"
+        "mime-db": "~1.37.0"
       }
     },
     "mimic-fn": {
@@ -1255,9 +1274,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "range-parser": {
@@ -1267,40 +1286,25 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "dev": true,
           "requires": {
-            "depd": "1.1.1",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
         }
       }
     },
@@ -1407,6 +1411,12 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "semver": {

--- a/rubicon-htb-system-tests.js
+++ b/rubicon-htb-system-tests.js
@@ -104,7 +104,6 @@ function getValidResponse(request, creative) {
 function validateTargeting(targetingMap) {
 	expect(targetingMap).toEqual(jasmine.objectContaining({
 		ix_rubi_om: jasmine.arrayContaining(["300x250_200"]),
-		hb_pb_ixrubicon: jasmine.arrayContaining(["200"]),
 		ix_rubi_id: jasmine.arrayContaining([jasmine.any(String)])
 	}));
 }
@@ -133,6 +132,54 @@ function getPassResponse() {
 	return JSON.stringify(skipResponse);
 }
 
+
+function getValidResponseWithDeal(request, creative) {
+	var adm = "</script>" + creative + "<script>";
+	var response = {
+		"status": "ok",
+		"account_id": 1234,
+		"site_id": 112233,
+		"zone_id": 556677,
+		"size_id": 15,
+		"tracking": "",
+		"inventory": {
+		},
+		"ads": [
+			{
+				"status": "ok",
+				"impression_id": "1234test-1234-12q1-12e4-c08098test",
+				"size_id": "15",
+				"ad_id": "6789",
+				"advertiser": 5678,
+				"network": 1902,
+				"creative_id": "1902:12345",
+				"type": "script",
+				"script": adm,
+				"campaign_id": 48985,
+				"rtb_rule_id": 1598010,
+				"cpm": 2,
+				"deal": 12345,
+				"targeting": [
+					{
+						"key": "rpfl_1234",
+						"values": ["deal_tierAll"]
+					}
+				]
+			}
+		]
+	};
+
+	return JSON.stringify(response);
+}
+
+function validateTargetingWithDeal(targetingMap) {
+	expect(targetingMap).toEqual(jasmine.objectContaining({
+		ix_rubi_om: jasmine.arrayContaining(["300x250_200"]),
+		ix_rubi_id: jasmine.arrayContaining([jasmine.any(String)]),
+		rpfl_1234: jasmine.arrayContaining(["deal_tierAll"]),
+	}));
+}
+
 module.exports = {
 	getPartnerId: getPartnerId,
 	getBidRequestRegex: getBidRequestRegex,
@@ -144,5 +191,7 @@ module.exports = {
 	validateBidRequestWithPrivacy: validateBidRequestWithPrivacy,
 	getValidResponse: getValidResponse,
 	validateTargeting: validateTargeting,
-	getPassResponse: getPassResponse
+	getPassResponse: getPassResponse,
+	getValidResponseWithDeal: getValidResponseWithDeal,
+	validateTargetingWithDeal: validateTargetingWithDeal
 };

--- a/rubicon-htb-system-tests.js
+++ b/rubicon-htb-system-tests.js
@@ -1,0 +1,148 @@
+"use strict";
+/* eslint indent: ["error", "tab"], "no-tabs": 0 */
+/* eslint quote-props: ["error", "as-needed", { "unnecessary": false }] */
+/* eslint quotes: ["error", "double"] */
+
+function getPartnerId() {
+	return "RubiconHtb";
+}
+
+function getBidRequestRegex() {
+	return {
+		method: "GET",
+		urlRegex: /.*fastlane\.rubiconproject\.com\/a\/api\/fastlane.json.*/
+	};
+}
+
+function getCallbackType() {
+	return "NONE";
+}
+
+function getArchitecture() {
+	return "MRA";
+}
+
+function getStatsId() {
+	return "RUBI";
+}
+
+function validateBidRequest(request) {
+	var r = request.query;
+
+	expect(r.account_id).toBe("1234");
+
+	expect(r.site_id).toBe("112233");
+
+	expect(r.zone_id).toBe("556677");
+
+	expect(r.size_id).toBe("15");
+
+	expect(r.alt_size_ids).toBe("10");
+
+	expect(r.rf).toEqual(jasmine.anything());
+}
+
+function validateBidRequestWithPrivacy(request) {
+	var r = request.query;
+
+	expect(r.gdpr).toBe("1");
+
+	expect(r.gdpr_consent).toBe("TEST_GDPR_CONSENT_STRING");
+}
+
+function getConfig() {
+	return {
+		"accountId": "1234",
+		"xSlots": {
+			"1": {
+				"siteId": "112233",
+				"zoneId": "556677",
+				"sizes": [[300, 250], [300, 600]]
+			}
+		}
+	};
+}
+
+function getValidResponse(request, creative) {
+	var adm = "</script>" + creative + "<script>";
+	var response = {
+		"status": "ok",
+		"account_id": 1234,
+		"site_id": 112233,
+		"zone_id": 556677,
+		"size_id": 15,
+		"tracking": "",
+		"inventory": {
+		},
+		"ads": [
+			{
+				"status": "ok",
+				"impression_id": "1234test-1234-12q1-12e4-c08098test",
+				"size_id": "15",
+				"ad_id": "6789",
+				"advertiser": 5678,
+				"network": 1902,
+				"creative_id": "1902:12345",
+				"type": "script",
+				"script": adm,
+				"campaign_id": 48985,
+				"rtb_rule_id": 1598010,
+				"cpm": 2,
+				"targeting": [
+					{
+						"key": "rpfl_1234",
+						"values": ["15_tier00015"]
+					}
+				]
+			}
+		]
+	};
+
+	return JSON.stringify(response);
+}
+
+function validateTargeting(targetingMap) {
+	expect(targetingMap).toEqual(jasmine.objectContaining({
+		ix_rubi_om: jasmine.arrayContaining(["300x250_200"]),
+		hb_pb_ixrubicon: jasmine.arrayContaining(["200"]),
+		ix_rubi_id: jasmine.arrayContaining([jasmine.any(String)])
+	}));
+}
+
+function getPassResponse() {
+	var skipResponse = {
+		"status": "ok",
+		"account_id": 1234,
+		"site_id": 112233,
+		"zone_id": 556677,
+		"size_id": 15,
+		"alt_size_ids": [10],
+		"tracking": "",
+		"inventory": {
+		},
+		"ads": [
+			{
+				"status": "no-ads",
+				"reason": "floor-not-met",
+				"error_code": "10",
+				"impression_id": "1234test-1234-12q1-12e4-c08098test"
+			}
+		]
+	};
+
+	return JSON.stringify(skipResponse);
+}
+
+module.exports = {
+	getPartnerId: getPartnerId,
+	getBidRequestRegex: getBidRequestRegex,
+	getCallbackType: getCallbackType,
+	getConfig: getConfig,
+	getArchitecture: getArchitecture,
+	getStatsId: getStatsId,
+	validateBidRequest: validateBidRequest,
+	validateBidRequestWithPrivacy: validateBidRequestWithPrivacy,
+	getValidResponse: getValidResponse,
+	validateTargeting: validateTargeting,
+	getPassResponse: getPassResponse
+};

--- a/rubicon-htb-system-tests.js
+++ b/rubicon-htb-system-tests.js
@@ -1,196 +1,193 @@
-"use strict";
-/* eslint indent: ["error", "tab"], "no-tabs": 0 */
-/* eslint quote-props: ["error", "as-needed", { "unnecessary": false }] */
-/* eslint quotes: ["error", "double"] */
+'use strict';
 
 function getPartnerId() {
-	return "RubiconHtb";
+    return 'RubiconHtb';
 }
 
 function getBidRequestRegex() {
-	return {
-		method: "GET",
-		urlRegex: /.*fastlane\.rubiconproject\.com\/a\/api\/fastlane.json.*/
-	};
+    return {
+        method: 'GET',
+        urlRegex: /.*fastlane\.rubiconproject\.com\/a\/api\/fastlane.json.*/
+    };
 }
 
 function getCallbackType() {
-	return "NONE";
+    return 'NONE';
 }
 
 function getArchitecture() {
-	return "MRA";
+    return 'MRA';
 }
 
 function getStatsId() {
-	return "RUBI";
+    return 'RUBI';
 }
 
 function validateBidRequest(request) {
-	var r = request.query;
+    var r = request.query;
 
-	expect(r.account_id).toBe("1234");
+    expect(r.account_id).toBe('1234');
 
-	expect(r.site_id).toBe("112233");
+    expect(r.site_id).toBe('112233');
 
-	expect(r.zone_id).toBe("556677");
+    expect(r.zone_id).toBe('556677');
 
-	expect(r.size_id).toBe("15");
+    expect(r.size_id).toBe('15');
 
-	expect(r.alt_size_ids).toBe("10");
+    expect(r.alt_size_ids).toBe('10');
 
-	expect(r.rf).toEqual(jasmine.anything());
+    expect(r.rf).toEqual(jasmine.anything());
 }
 
 function validateBidRequestWithPrivacy(request) {
-	var r = request.query;
+    var r = request.query;
 
-	expect(r.gdpr).toBe("1");
+    expect(r.gdpr).toBe('1');
 
-	expect(r.gdpr_consent).toBe("TEST_GDPR_CONSENT_STRING");
+    expect(r.gdpr_consent).toBe('TEST_GDPR_CONSENT_STRING');
 }
 
 function getConfig() {
-	return {
-		"accountId": "1234",
-		"xSlots": {
-			"1": {
-				"siteId": "112233",
-				"zoneId": "556677",
-				"sizes": [[300, 250], [300, 600]]
-			}
-		}
-	};
+    return {
+        accountId: '1234',
+        xSlots: {
+            1: {
+                siteId: '112233',
+                zoneId: '556677',
+                sizes: [[300, 250], [300, 600]]
+            }
+        }
+    };
 }
 
 function getValidResponse(request, creative) {
-	var adm = "</script>" + creative + "<script>";
-	var response = {
-		"status": "ok",
-		"account_id": 1234,
-		"site_id": 112233,
-		"zone_id": 556677,
-		"size_id": 15,
-		"tracking": "",
-		"inventory": {
-		},
-		"ads": [
-			{
-				"status": "ok",
-				"impression_id": "1234test-1234-12q1-12e4-c08098test",
-				"size_id": "15",
-				"ad_id": "6789",
-				"advertiser": 5678,
-				"network": 1902,
-				"creative_id": "1902:12345",
-				"type": "script",
-				"script": adm,
-				"campaign_id": 48985,
-				"rtb_rule_id": 1598010,
-				"cpm": 2,
-				"targeting": [
-					{
-						"key": "rpfl_1234",
-						"values": ["15_tier00015"]
-					}
-				]
-			}
-		]
-	};
+    var adm = '</script>' + creative + '<script>';
+    var response = {
+        status: 'ok',
+        account_id: 1234,
+        site_id: 112233,
+        zone_id: 556677,
+        size_id: 15,
+        tracking: '',
+        inventory: {
+        },
+        ads: [
+            {
+                status: 'ok',
+                impression_id: '1234test-1234-12q1-12e4-c08098test',
+                size_id: '15',
+                ad_id: '6789',
+                advertiser: 5678,
+                network: 1902,
+                creative_id: '1902:12345',
+                type: 'script',
+                script: adm,
+                campaign_id: 48985,
+                rtb_rule_id: 1598010,
+                cpm: 2,
+                targeting: [
+                    {
+                        key: 'rpfl_1234',
+                        values: ['15_tier00015']
+                    }
+                ]
+            }
+        ]
+    };
 
-	return JSON.stringify(response);
+    return JSON.stringify(response);
 }
 
 function validateTargeting(targetingMap) {
-	expect(targetingMap).toEqual(jasmine.objectContaining({
-		ix_rubi_om: jasmine.arrayContaining(["300x250_200"]),
-		ix_rubi_id: jasmine.arrayContaining([jasmine.any(String)])
-	}));
+    expect(targetingMap).toEqual(jasmine.objectContaining({
+        ix_rubi_om: jasmine.arrayContaining(['300x250_200']),
+        ix_rubi_id: jasmine.arrayContaining([jasmine.any(String)])
+    }));
 }
 
 function getPassResponse() {
-	var skipResponse = {
-		"status": "ok",
-		"account_id": 1234,
-		"site_id": 112233,
-		"zone_id": 556677,
-		"size_id": 15,
-		"alt_size_ids": [10],
-		"tracking": "",
-		"inventory": {
-		},
-		"ads": [
-			{
-				"status": "no-ads",
-				"reason": "floor-not-met",
-				"error_code": "10",
-				"impression_id": "1234test-1234-12q1-12e4-c08098test"
-			}
-		]
-	};
+    var skipResponse = {
+        status: 'ok',
+        account_id: 1234,
+        site_id: 112233,
+        zone_id: 556677,
+        size_id: 15,
+        alt_size_ids: [10],
+        tracking: '',
+        inventory: {
+        },
+        ads: [
+            {
+                status: 'no-ads',
+                reason: 'floor-not-met',
+                error_code: '10',
+                impression_id: '1234test-1234-12q1-12e4-c08098test'
+            }
+        ]
+    };
 
-	return JSON.stringify(skipResponse);
+    return JSON.stringify(skipResponse);
 }
 
 function getValidResponseWithDeal(request, creative) {
-	var adm = "</script>" + creative + "<script>";
-	var response = {
-		"status": "ok",
-		"account_id": 1234,
-		"site_id": 112233,
-		"zone_id": 556677,
-		"size_id": 15,
-		"tracking": "",
-		"inventory": {
-		},
-		"ads": [
-			{
-				"status": "ok",
-				"impression_id": "1234test-1234-12q1-12e4-c08098test",
-				"size_id": "15",
-				"ad_id": "6789",
-				"advertiser": 5678,
-				"network": 1902,
-				"creative_id": "1902:12345",
-				"type": "script",
-				"script": adm,
-				"campaign_id": 48985,
-				"rtb_rule_id": 1598010,
-				"cpm": 2,
-				"deal": 12345,
-				"targeting": [
-					{
-						"key": "rpfl_1234",
-						"values": ["deal_tierAll"]
-					}
-				]
-			}
-		]
-	};
+    var adm = '</script>' + creative + '<script>';
+    var response = {
+        status: 'ok',
+        account_id: 1234,
+        site_id: 112233,
+        zone_id: 556677,
+        size_id: 15,
+        tracking: '',
+        inventory: {
+        },
+        ads: [
+            {
+                status: 'ok',
+                impression_id: '1234test-1234-12q1-12e4-c08098test',
+                size_id: '15',
+                ad_id: '6789',
+                advertiser: 5678,
+                network: 1902,
+                creative_id: '1902:12345',
+                type: 'script',
+                script: adm,
+                campaign_id: 48985,
+                rtb_rule_id: 1598010,
+                cpm: 2,
+                deal: 12345,
+                targeting: [
+                    {
+                        key: 'rpfl_1234',
+                        values: ['deal_tierAll']
+                    }
+                ]
+            }
+        ]
+    };
 
-	return JSON.stringify(response);
+    return JSON.stringify(response);
 }
 
 function validateTargetingWithDeal(targetingMap) {
-	expect(targetingMap).toEqual(jasmine.objectContaining({
-		ix_rubi_om: jasmine.arrayContaining(["300x250_200"]),
-		ix_rubi_id: jasmine.arrayContaining([jasmine.any(String)]),
-		rpfl_1234: jasmine.arrayContaining(["deal_tierAll"])
-	}));
+    expect(targetingMap).toEqual(jasmine.objectContaining({
+        ix_rubi_om: jasmine.arrayContaining(['300x250_200']),
+        ix_rubi_id: jasmine.arrayContaining([jasmine.any(String)]),
+        rpfl_1234: jasmine.arrayContaining(['deal_tierAll'])
+    }));
 }
 
 module.exports = {
-	getPartnerId: getPartnerId,
-	getBidRequestRegex: getBidRequestRegex,
-	getCallbackType: getCallbackType,
-	getConfig: getConfig,
-	getArchitecture: getArchitecture,
-	getStatsId: getStatsId,
-	validateBidRequest: validateBidRequest,
-	validateBidRequestWithPrivacy: validateBidRequestWithPrivacy,
-	getValidResponse: getValidResponse,
-	validateTargeting: validateTargeting,
-	getPassResponse: getPassResponse,
-	getValidResponseWithDeal: getValidResponseWithDeal,
-	validateTargetingWithDeal: validateTargetingWithDeal
+    getPartnerId: getPartnerId,
+    getBidRequestRegex: getBidRequestRegex,
+    getCallbackType: getCallbackType,
+    getConfig: getConfig,
+    getArchitecture: getArchitecture,
+    getStatsId: getStatsId,
+    validateBidRequest: validateBidRequest,
+    validateBidRequestWithPrivacy: validateBidRequestWithPrivacy,
+    getValidResponse: getValidResponse,
+    validateTargeting: validateTargeting,
+    getPassResponse: getPassResponse,
+    getValidResponseWithDeal: getValidResponseWithDeal,
+    validateTargetingWithDeal: validateTargetingWithDeal
 };

--- a/rubicon-htb-system-tests.js
+++ b/rubicon-htb-system-tests.js
@@ -132,7 +132,6 @@ function getPassResponse() {
 	return JSON.stringify(skipResponse);
 }
 
-
 function getValidResponseWithDeal(request, creative) {
 	var adm = "</script>" + creative + "<script>";
 	var response = {
@@ -176,7 +175,7 @@ function validateTargetingWithDeal(targetingMap) {
 	expect(targetingMap).toEqual(jasmine.objectContaining({
 		ix_rubi_om: jasmine.arrayContaining(["300x250_200"]),
 		ix_rubi_id: jasmine.arrayContaining([jasmine.any(String)]),
-		rpfl_1234: jasmine.arrayContaining(["deal_tierAll"]),
+		rpfl_1234: jasmine.arrayContaining(["deal_tierAll"])
 	}));
 }
 

--- a/rubicon-htb-validator.js
+++ b/rubicon-htb-validator.js
@@ -22,7 +22,7 @@ var Inspector = require('../../../libs/external/schema-inspector.js');
 // Main ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-var partnerValidator = function (configs) {
+function partnerValidator(configs) {
     var result = Inspector.validate({
         type: 'object',
         properties: {
@@ -326,6 +326,6 @@ var partnerValidator = function (configs) {
     }
 
     return null;
-};
+}
 
 module.exports = partnerValidator;

--- a/rubicon-htb.js
+++ b/rubicon-htb.js
@@ -11,7 +11,6 @@
  */
 
 /* eslint no-eval: 0 */
-/* eslint no-console: ["error", { allow: ["warn", "error"] }] */
 /* eslint camelcase: [2, {properties: "never"}] */
 
 'use strict';
@@ -276,7 +275,6 @@ function RubiconModule(configs) {
                 try {
                     _window = window.top;
                 } catch (e) {
-                    console.warn('impossible to reach top window, get topmost accessible window context');
                     _window = Browser.topWindow;
                 }
             } else {
@@ -285,9 +283,7 @@ function RubiconModule(configs) {
 
             try {
                 digiTrustUser = _window.DigiTrust.getUser({ member: 'T9QSFKPDN9' });
-            } catch (e) {
-                console.warn('digiTrustUser not defined');
-            }
+            } catch (e) {}
 
             return (digiTrustUser && digiTrustUser.success && digiTrustUser.identity) || null;
         }

--- a/rubicon-htb.js
+++ b/rubicon-htb.js
@@ -808,7 +808,9 @@ function RubiconModule(configs) {
             '800x250': 125,
             '200x600': 126,
             '320x250': 159,
-            '970x1000': 264
+            '970x1000': 264,
+            '840x250': 158,
+            '840x150': 147
         };
 
         __baseUrl = Browser.getProtocol() + '//fastlane.rubiconproject.com/a/api/fastlane.json';

--- a/rubicon-htb.js
+++ b/rubicon-htb.js
@@ -596,43 +596,35 @@ function RubiconModule(configs) {
             curReturnParcel.targeting = {};
 
             var targetingCpm = '';
-            var rubiSizeId = '';
 
             //? if(FEATURES.GPT_LINE_ITEMS) {
             targetingCpm = __baseClass._bidTransformers.targeting.apply(bidPrice);
 
-            if (__baseClass._configs.lineItemType === Constants.LineItemTypes.CUSTOM) {
-                if (bids[i].targeting) {
-                    var rubiTargeting = bids[i].targeting;
-                    rubiSizeId = bids[i].size_id;
+            if (bids[i].targeting) {
+                var rubiTargeting = bids[i].targeting;
 
-                    for (var j = 0; j < rubiTargeting.length; j++) {
-                        curReturnParcel.targeting[rubiTargeting[j].key] = rubiTargeting[j].values;
-                    }
+                for (var j = 0; j < rubiTargeting.length; j++) {
+                    curReturnParcel.targeting[rubiTargeting[j].key] = rubiTargeting[j].values;
                 }
-
-                if (bidDealId) {
-                    curReturnParcel.targeting.hb_deal_ixrubicon = bidDealId;
-                }
-
-                curReturnParcel.targeting.rpfl_elemid = [curReturnParcel.requestId];
-                curReturnParcel.targeting.hb_pb_ixrubicon = targetingCpm;
-            } else {
-                var sizeKey = Size.arrayToString(curReturnParcel.size);
-
-                if (bidDealId) {
-                    curReturnParcel.targeting.hb_deal_ixrubicon = bidDealId;
-                    curReturnParcel.targeting[__baseClass._configs.targetingKeys.pm] = [sizeKey + '_' + bidDealId];
-                }
-
-                /* Set the om key as long as they sent _something_ in the cpm, even if it was zero */
-                if (bids[i].hasOwnProperty('cpm')) {
-                    curReturnParcel.targeting[__baseClass._configs.targetingKeys.om] = [sizeKey + '_' + targetingCpm];
-                }
-
-                curReturnParcel.targeting.hb_pb_ixrubicon = targetingCpm;
-                curReturnParcel.targeting[__baseClass._configs.targetingKeys.id] = [curReturnParcel.requestId];
             }
+
+            curReturnParcel.targeting.rpfl_elemid = [curReturnParcel.requestId];
+            curReturnParcel.targeting.hb_pb_ixrubicon = targetingCpm;
+
+            var sizeKey = Size.arrayToString(curReturnParcel.size);
+
+            if (bidDealId) {
+                curReturnParcel.targeting.hb_deal_ixrubicon = bidDealId;
+                curReturnParcel.targeting[__baseClass._configs.targetingKeys.pm] = [sizeKey + '_' + bidDealId];
+            }
+
+            /* Set the om key as long as they sent _something_ in the cpm, even if it was zero */
+            if (bids[i].hasOwnProperty('cpm')) {
+                curReturnParcel.targeting[__baseClass._configs.targetingKeys.om] = [sizeKey + '_' + targetingCpm];
+            }
+
+            curReturnParcel.targeting.hb_pb_ixrubicon = targetingCpm;
+            curReturnParcel.targeting[__baseClass._configs.targetingKeys.id] = [curReturnParcel.requestId];
 
             //? }
 
@@ -649,7 +641,7 @@ function RubiconModule(configs) {
                 partnerId: __profile.partnerId,
                 adm: bidCreative,
                 requestId: curReturnParcel.requestId,
-                size: rubiSizeId ? rubiSizeId : curReturnParcel.size,
+                size: curReturnParcel.size,
                 price: targetingCpm ? targetingCpm : '',
                 dealId: bidDealId ? bidDealId : '',
                 timeOfExpiry: __profile.features.demandExpiry.enabled ? __profile.features.demandExpiry.value + System.now() : 0 // eslint-disable-line

--- a/rubicon-htb.js
+++ b/rubicon-htb.js
@@ -600,31 +600,39 @@ function RubiconModule(configs) {
             //? if(FEATURES.GPT_LINE_ITEMS) {
             targetingCpm = __baseClass._bidTransformers.targeting.apply(bidPrice);
 
-            if (bids[i].targeting) {
-                var rubiTargeting = bids[i].targeting;
+            if (__baseClass._configs.lineItemType === Constants.LineItemTypes.CUSTOM) {
+                if (bids[i].targeting) {
+                    var rubiTargeting = bids[i].targeting;
 
-                for (var j = 0; j < rubiTargeting.length; j++) {
-                    curReturnParcel.targeting[rubiTargeting[j].key] = rubiTargeting[j].values;
+                    for (var j = 0; j < rubiTargeting.length; j++) {
+                        curReturnParcel.targeting[rubiTargeting[j].key] = rubiTargeting[j].values;
+                    }
                 }
+                curReturnParcel.targeting.rpfl_elemid = [curReturnParcel.requestId];
+            } else {
+                var sizeKey = Size.arrayToString(curReturnParcel.size);
+
+                if (bidDealId) {
+                    curReturnParcel.targeting[__baseClass._configs.targetingKeys.pm] = [sizeKey + '_' + bidDealId];
+
+                    /* Set the custom KVPs for deal only so Rubicon handle tier deal line items */
+
+                    if (bids[i].targeting) {
+                        var rubiTargetingDeal = bids[i].targeting;
+                        for (var k = 0; k < rubiTargetingDeal.length; k++) {
+                            curReturnParcel.targeting[rubiTargetingDeal[k].key] = rubiTargetingDeal[k].values;
+                        }
+                    }
+                }
+
+                /* Set the om key as long as they sent _something_ in the cpm, even if it was zero */
+
+                if (bids[i].hasOwnProperty('cpm')) {
+                    curReturnParcel.targeting[__baseClass._configs.targetingKeys.om] = [sizeKey + '_' + targetingCpm];
+                }
+
+                curReturnParcel.targeting[__baseClass._configs.targetingKeys.id] = [curReturnParcel.requestId];
             }
-
-            curReturnParcel.targeting.rpfl_elemid = [curReturnParcel.requestId];
-            curReturnParcel.targeting.hb_pb_ixrubicon = targetingCpm;
-
-            var sizeKey = Size.arrayToString(curReturnParcel.size);
-
-            if (bidDealId) {
-                curReturnParcel.targeting[__baseClass._configs.targetingKeys.pm] = [sizeKey + '_' + bidDealId];
-            }
-
-            /* Set the om key as long as they sent _something_ in the cpm, even if it was zero */
-            if (bids[i].hasOwnProperty('cpm')) {
-                curReturnParcel.targeting[__baseClass._configs.targetingKeys.om] = [sizeKey + '_' + targetingCpm];
-            }
-
-            curReturnParcel.targeting.hb_pb_ixrubicon = targetingCpm;
-            curReturnParcel.targeting[__baseClass._configs.targetingKeys.id] = [curReturnParcel.requestId];
-
             //? }
 
             //? if(FEATURES.RETURN_CREATIVE) {

--- a/rubicon-htb.js
+++ b/rubicon-htb.js
@@ -614,7 +614,6 @@ function RubiconModule(configs) {
             var sizeKey = Size.arrayToString(curReturnParcel.size);
 
             if (bidDealId) {
-                curReturnParcel.targeting.hb_deal_ixrubicon = bidDealId;
                 curReturnParcel.targeting[__baseClass._configs.targetingKeys.pm] = [sizeKey + '_' + bidDealId];
             }
 

--- a/rubicon-htb.js
+++ b/rubicon-htb.js
@@ -415,7 +415,7 @@ function RubiconModule(configs) {
             site_id: parcel.xSlotRef.siteId,
             zone_id: parcel.xSlotRef.zoneId,
             kw: 'rp.fastlane',
-            tk_flint: 'custom',
+            tk_flint: 'index',
             rand: Math.random(),
             dt: _getDigiTrustQueryParams()
         };

--- a/rubicon-htb.js
+++ b/rubicon-htb.js
@@ -10,9 +10,6 @@
  * prior written permission of Index Exchange.
  */
 
-/* eslint no-eval: 0 */
-/* eslint camelcase: [2, {properties: "never"}] */
-
 'use strict';
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -152,7 +149,9 @@ function RubiconModule(configs) {
 
     function __evalVariable(variableString) {
         try {
+            /* eslint-disable no-eval */
             return eval.call(null, variableString);
+            /* eslint-enable no-eval */
         } catch (ex) {
             //? if (DEBUG) {
             Scribe.error('Error evaluating variable ' + variableString + ': ' + ex);
@@ -164,7 +163,9 @@ function RubiconModule(configs) {
 
     function __evalFunction(functionString, args) {
         try {
+            /* eslint-disable no-eval */
             return eval.call(null, functionString + '(' + args.join() + ')');
+            /* eslint-enable no-eval */
         } catch (ex) {
             //? if (DEBUG) {
             Scribe.error('Error evaluating function ' + functionString + ': ' + ex);
@@ -403,7 +404,7 @@ function RubiconModule(configs) {
 
         var gdprConsent = ComplianceService.gdpr && ComplianceService.gdpr.getConsent();
         var privacyEnabled = ComplianceService.isPrivacyEnabled();
-
+        /* eslint-disable camelcase */
         var queryObj = {
             account_id: configs.accountId,
             size_id: rubiSizeIds[0],
@@ -418,12 +419,14 @@ function RubiconModule(configs) {
             rand: Math.random(),
             dt: _getDigiTrustQueryParams()
         };
-
+        /* eslint-enable camelcase */
         if (gdprConsent && privacyEnabled && typeof gdprConsent === 'object') {
             if (typeof gdprConsent.applies === 'boolean') {
                 queryObj.gdpr = Number(gdprConsent.applies);
             }
+            /* eslint-disable camelcase */
             queryObj.gdpr_consent = gdprConsent.consentString;
+            /* eslint-enable camelcase */
         }
 
         for (var pageInv in pageFirstPartyData.inventory) {
@@ -478,8 +481,10 @@ function RubiconModule(configs) {
         }
 
         if (rubiSizeIds.length > 1) {
+            /* eslint-disable camelcase */
             queryObj.alt_size_ids = rubiSizeIds.slice(1)
                 .join(',');
+            /* eslint-enable camelcase */
         }
 
         return {
@@ -608,7 +613,9 @@ function RubiconModule(configs) {
                         curReturnParcel.targeting[rubiTargeting[j].key] = rubiTargeting[j].values;
                     }
                 }
+                /* eslint-disable camelcase */
                 curReturnParcel.targeting.rpfl_elemid = [curReturnParcel.requestId];
+                /* eslint-enable camelcase */
             } else {
                 var sizeKey = Size.arrayToString(curReturnParcel.size);
 


### PR DESCRIPTION
Here is an update of the Rubicon Adapter:
- the test file has been added with 8 tests and 8 success (system-tester.html)
- the adapter file has been cleaned and make sure it pass ESLint
- some edit to change the rubicon key (hb_pb_ixrubicon) for reporting only
- the ad is correctly displayed on both the safeFrame and no safeFrame slots
-2 sizes have been added to the sizeToSizeIdMapping

The target would be to move all the account to use the standard LineItemTypes config and not custom. So all KV are passed and anot distinction between custom and standard lineItemTypes. The goal is to migrate all current account so line items used by DFP will now target ix_rubi_om = targetingCpm  
It will make the setup easier, with less potential error and make all bidders compete on same granularity.

PR checklist:
1- Check that all the following files are complete and up-to-date:  OK
2- Check that your adapter version number is up-to-date: OK
3- Check that bidder documentation is up-to-date: OK
4- Check that your CHANGES.md file is up-to-date: OK
5- Run the linter: OK
6- Run the system tests: OK